### PR TITLE
Add raw object logging for AWSMachineDeployment admission

### DIFF
--- a/pkg/awsmachinedeployment/admit_awsmachinedeployment.go
+++ b/pkg/awsmachinedeployment/admit_awsmachinedeployment.go
@@ -79,8 +79,8 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 
 	// General debugging
 	a.Log("level", "debug", "message", "AWSMachineDeployment modification admission request")
-	a.Log("level", "debug", "message", fmt.Sprintf("Old object: %#v", request.OldObject.Raw))
-	a.Log("level", "debug", "message", fmt.Sprintf("New object: %#v", request.Object.Raw))
+	a.Log("level", "debug", "message", fmt.Sprintf("Old object: %q", string(request.OldObject.Raw)))
+	a.Log("level", "debug", "message", fmt.Sprintf("New object: %q", string(request.Object.Raw)))
 
 	var result []admission.PatchOperation
 

--- a/pkg/awsmachinedeployment/admit_awsmachinedeployment.go
+++ b/pkg/awsmachinedeployment/admit_awsmachinedeployment.go
@@ -77,6 +77,11 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse AWSMachineDeployment: %v", err)
 	}
 
+	// General debugging
+	a.Log("level", "debug", "message", "AWSMachineDeployment modification admission request")
+	a.Log("level", "debug", "message", fmt.Sprintf("Old object: %#v", request.OldObject.Raw))
+	a.Log("level", "debug", "message", fmt.Sprintf("New object: %#v", request.Object.Raw))
+
 	var result []admission.PatchOperation
 
 	// Default the OnDemandPercentageAboveBaseCapacity.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11956

This enables printing of full request payloads.