### PR TITLE
Move AWSControlPlane InstanceType defaulting and defaulting for pre HA versions

### DIFF
--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -8,6 +8,9 @@ const (
 	// DefaultMasterReplicas is the default number of master node replicas
 	DefaultMasterReplicas = 3
 
+	// DefaultMasterInstanceType is the default master instance type
+	DefaultMasterInstanceType = "m5.xlarge"
+
 	// FirstHARelease is the first GS release for AWS that supports HA Masters
 	FirstHARelease = "11.4.0"
 )


### PR DESCRIPTION
This is a sub PR towards https://github.com/giantswarm/giantswarm/issues/12231
We want to move all defaulting rules from OPA to the admission-controller