### PR TITLE
moving g8scontrolplane defaulting

### DIFF
--- a/pkg/aws/g8scontrolplane/admit_g8scontrolplane_AZ_test.go
+++ b/pkg/aws/g8scontrolplane/admit_g8scontrolplane_AZ_test.go
@@ -24,7 +24,7 @@ var (
 	controlPlaneNameSpace = "default"
 )
 
-func TestG8sControlPlaneAdmit(t *testing.T) {
+func TestAZG8sControlPlaneAdmit(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		ctx                     context.Context
@@ -85,7 +85,7 @@ func TestG8sControlPlaneAdmit(t *testing.T) {
 			}
 
 			// run admission request to update AWSControlPlane AZ's
-			_, err = admit.Admit(g8sControlPlaneAdmissionRequest())
+			_, err = admit.Admit(g8sControlPlaneUpdateAdmissionRequest())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -127,7 +127,7 @@ func TestG8sControlPlaneAdmit(t *testing.T) {
 	}
 }
 
-func g8sControlPlaneAdmissionRequest() *v1beta1.AdmissionRequest {
+func g8sControlPlaneUpdateAdmissionRequest() *v1beta1.AdmissionRequest {
 	req := &v1beta1.AdmissionRequest{
 		Kind: metav1.GroupVersionKind{
 			Version: "infrastructure.giantswarm.io/v1alpha2",

--- a/pkg/aws/g8scontrolplane/admit_g8scontrolplane_replicas_test.go
+++ b/pkg/aws/g8scontrolplane/admit_g8scontrolplane_replicas_test.go
@@ -55,6 +55,14 @@ func TestReplicasG8sControlPlaneAdmit(t *testing.T) {
 			currentReplicas:         1,
 			expectReplicas:          0,
 		},
+		{
+			name: "case 4",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: nil,
+			currentReplicas:         3,
+			expectReplicas:          0,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/aws/g8scontrolplane/admit_g8scontrolplane_replicas_test.go
+++ b/pkg/aws/g8scontrolplane/admit_g8scontrolplane_replicas_test.go
@@ -1,0 +1,125 @@
+package g8scontrolplane
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/admission-controller/pkg/admission"
+	"github.com/giantswarm/admission-controller/pkg/unittest"
+)
+
+func TestReplicasG8sControlPlaneAdmit(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		ctx                     context.Context
+		currentAvailabilityZone []string
+		currentReplicas         int
+		expectReplicas          int
+	}{
+		{
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: []string{"eu-central-1a"},
+			currentReplicas:         0,
+			expectReplicas:          1,
+		},
+		{
+			name: "case 1",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
+			currentReplicas:         0,
+			expectReplicas:          3,
+		},
+		{
+			name: "case 2",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: nil,
+			currentReplicas:         0,
+			expectReplicas:          3,
+		},
+		{
+			name: "case 3",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: nil,
+			currentReplicas:         1,
+			expectReplicas:          0,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+			var updatedReplicas int
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+			fakeK8sClient := unittest.FakeK8sClient()
+			admit := &Admitter{
+				validAvailabilityZones: []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
+				k8sClient:              fakeK8sClient,
+				logger:                 newLogger,
+			}
+
+			// create AWSControlPlane with the current AZ which belongs to G8sControlPlane if needed
+			if tc.currentAvailabilityZone != nil {
+				err = fakeK8sClient.CtrlClient().Create(tc.ctx, awsControlPlane(tc.currentAvailabilityZone))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// run admission request to default replicas
+			var patch []admission.PatchOperation
+			patch, err = admit.Admit(g8sControlPlaneCreateAdmissionRequest(tc.currentReplicas))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// parse patches
+			for _, p := range patch {
+				if p.Path == "/spec/replicas" {
+					updatedReplicas = p.Value.(int)
+				}
+			}
+			// check if the values of Replicas is as expected
+			if tc.expectReplicas != updatedReplicas {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectReplicas, updatedReplicas)
+			}
+		})
+	}
+}
+
+func g8sControlPlaneCreateAdmissionRequest(replicas int) *v1beta1.AdmissionRequest {
+	req := &v1beta1.AdmissionRequest{
+		Kind: metav1.GroupVersionKind{
+			Version: "infrastructure.giantswarm.io/v1alpha2",
+			Kind:    "G8sControlPlane",
+		},
+		Resource: metav1.GroupVersionResource{
+			Version:  "infrastructure.giantswarm.io/v1alpha2",
+			Resource: "g8scontrolplanes",
+		},
+		Operation: v1beta1.Create,
+		Object: runtime.RawExtension{
+			Raw:    getG8sControlPlaneRAWByte(replicas),
+			Object: nil,
+		},
+	}
+	return req
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/12231
We want to move the g8scontrolplane defaulting from OPA to admission-controller