### PR TITLE
Moving the infrastructure reference update from the API to admission-controller

### DIFF
--- a/helm/admission-controller/templates/rbac.yaml
+++ b/helm/admission-controller/templates/rbac.yaml
@@ -8,6 +8,8 @@ rules:
   - apiGroups:
       - infrastructure.giantswarm.io
     resources:
+      - awsclusters
+      - awsclusters/status
       - awscontrolplanes
       - awscontrolplanes/status
       - awsmachinedeployments

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane.go
@@ -99,10 +99,11 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 			g8sControlPlane := &infrastructurev1alpha2.G8sControlPlane{}
 			{
 				a.Log("level", "debug", "message", fmt.Sprintf("Fetching G8sControlPlane %s", awsControlPlaneCR.Name))
-				err := a.k8sClient.CtrlClient().Get(ctx,
-					types.NamespacedName{Name: awsControlPlaneCR.GetName(),
-						Namespace: awsControlPlaneCR.GetNamespace()},
-					g8sControlPlane)
+				err := a.k8sClient.CtrlClient().Get(
+					ctx,
+					types.NamespacedName{Name: awsControlPlaneCR.GetName(), Namespace: awsControlPlaneCR.GetNamespace()},
+					g8sControlPlane,
+				)
 				if err != nil {
 					return microerror.Maskf(aws.NotFoundError, "failed to fetch G8sControlplane: %v", err)
 				}

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane.go
@@ -115,14 +115,14 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 					a.Log("level", "debug", "message", fmt.Sprintf("Updating infrastructure reference to  %s", awsControlPlaneCR.Name))
 					infrastructureCRRef, err := reference.GetReference(infrastructurev1alpha2scheme.Scheme, awsControlPlaneCR)
 					if err != nil {
-						return microerror.Maskf(aws.ExecutionFailedError, "failed to create reference to AWSControlplane: %v", err)
+						microerror.Mask(err)
 					}
 
 					// We update the reference in the CR
 					g8sControlPlane.Spec.InfrastructureRef = *infrastructureCRRef
 					err = a.k8sClient.CtrlClient().Update(ctx, g8sControlPlane)
 					if err != nil {
-						return microerror.Maskf(aws.ExecutionFailedError, "failed to update G8sControlplane: %v", err)
+						microerror.Mask(err)
 					}
 				}
 			}

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane.go
@@ -11,6 +11,7 @@ import (
 	"github.com/blang/semver"
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
 	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	infrastructurev1alpha2scheme "github.com/giantswarm/apiextensions/pkg/clientset/versioned/scheme"
 	"github.com/giantswarm/apiextensions/pkg/label"
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
@@ -19,6 +20,7 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/reference"
 	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/admission-controller/pkg/admission"
@@ -81,10 +83,58 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 	}
 
 	var result []admission.PatchOperation
+	var numberOfAZs int
 
-	// We only need to default if attributes are not set
-	if awsControlPlaneCR.Spec.AvailabilityZones != nil && awsControlPlaneCR.Spec.InstanceType != "" {
+	// We only need to manipulate if attributes are not set or it's a create operation
+	if awsControlPlaneCR.Spec.AvailabilityZones != nil && awsControlPlaneCR.Spec.InstanceType != "" && request.Operation != "CREATE" {
 		return result, nil
+	}
+	// We need to fetch the G8sControlPlane in case AZs need to be defaulted or the awscontrolplane is just created
+	if (aws.IsHAVersion(releaseVersion) && awsControlPlaneCR.Spec.AvailabilityZones == nil) || request.Operation == "CREATE" {
+		numberOfAZs = aws.DefaultMasterReplicas
+		fetch := func() error {
+			ctx := context.Background()
+
+			// We try to fetch the G8sControlPlane CR.
+			g8sControlPlane := &infrastructurev1alpha2.G8sControlPlane{}
+			{
+				a.Log("level", "debug", "message", fmt.Sprintf("Fetching G8sControlPlane %s", awsControlPlaneCR.Name))
+				err := a.k8sClient.CtrlClient().Get(ctx,
+					types.NamespacedName{Name: awsControlPlaneCR.GetName(),
+						Namespace: awsControlPlaneCR.GetNamespace()},
+					g8sControlPlane)
+				if err != nil {
+					return microerror.Maskf(aws.NotFoundError, "failed to fetch G8sControlplane: %v", err)
+				}
+			}
+			numberOfAZs = g8sControlPlane.Spec.Replicas
+			{
+				// If the infrastructure reference is not set, we do it here
+				if request.Operation == "CREATE" && g8sControlPlane.Spec.InfrastructureRef.Name == "" {
+					a.Log("level", "debug", "message", fmt.Sprintf("Updating infrastructure reference to  %s", awsControlPlaneCR.Name))
+					infrastructureCRRef, err := reference.GetReference(infrastructurev1alpha2scheme.Scheme, awsControlPlaneCR)
+					if err != nil {
+						return microerror.Maskf(aws.ExecutionFailedError, "failed to create reference to AWSControlplane: %v", err)
+					}
+
+					// We update the reference in the CR
+					g8sControlPlane.Spec.InfrastructureRef = *infrastructureCRRef
+					err = a.k8sClient.CtrlClient().Update(ctx, g8sControlPlane)
+					if err != nil {
+						return microerror.Maskf(aws.ExecutionFailedError, "failed to update G8sControlplane: %v", err)
+					}
+				}
+			}
+			return nil
+		}
+		b := backoff.NewMaxRetries(3, 1*time.Second)
+		err = backoff.Retry(fetch, b)
+		// Note that while we do log the error, we don't fail if the g8sControlPlane doesn't exist yet. That is okay because the order of CR creation can vary.
+		if aws.IsNotFound(err) {
+			a.Log("level", "debug", "message", fmt.Sprintf("No G8sControlPlane %s could be found: %v", awsControlPlaneCR.Name, err))
+		} else if err != nil {
+			return nil, err
+		}
 	}
 	if aws.IsHAVersion(releaseVersion) {
 		// Trigger defaulting of the master instance type
@@ -96,30 +146,6 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 		// Trigger defaulting of the master availability zones
 		if awsControlPlaneCR.Spec.AvailabilityZones == nil {
 			a.Log("level", "debug", "message", fmt.Sprintf("AWSControlPlane %s AvailabilityZones is nil and will be defaulted", awsControlPlaneCR.ObjectMeta.Name))
-			numberOfAZs := aws.DefaultMasterReplicas
-			fetch := func() error {
-				ctx := context.Background()
-
-				// We try to fetch the G8sControlPlane CR.
-				g8sControlPlane := &infrastructurev1alpha2.G8sControlPlane{}
-				{
-					a.Log("level", "debug", "message", fmt.Sprintf("Fetching G8sControlPlane %s", awsControlPlaneCR.Name))
-					err := a.k8sClient.CtrlClient().Get(ctx,
-						types.NamespacedName{Name: awsControlPlaneCR.GetName(),
-							Namespace: awsControlPlaneCR.GetNamespace()},
-						g8sControlPlane)
-					if err != nil {
-						return microerror.Maskf(aws.NotFoundError, "failed to fetch G8sControlplane: %v", err)
-					}
-				}
-				numberOfAZs = g8sControlPlane.Spec.Replicas
-				return nil
-			}
-			b := backoff.NewMaxRetries(3, 1*time.Second)
-			err = backoff.Retry(fetch, b)
-			if err != nil {
-				a.Log("level", "debug", "message", fmt.Sprintf("No G8sControlPlane %s could be found", awsControlPlaneCR.Name))
-			}
 			// We default the AZs
 			defaultedAZs := a.getNavailabilityZones(numberOfAZs, a.validAvailabilityZones)
 			patch := admission.PatchAdd("/spec/availabilityZones", defaultedAZs)

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane.go
@@ -154,7 +154,7 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 		b := backoff.NewMaxRetries(3, 1*time.Second)
 		err = backoff.Retry(fetch, b)
 		if err != nil {
-			a.Log("level", "debug", "message", fmt.Sprintf("No AWSCluster for AWSControlPlane %s could be found", awsControlPlaneCR.Name))
+			a.Log("level", "debug", "message", fmt.Sprintf("No AWSCluster for AWSControlPlane %s could be found: %v", awsControlPlaneCR.Name, err))
 		}
 		// Trigger defaulting of the master instance type
 		if awsControlPlaneCR.Spec.InstanceType == "" {

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane.go
@@ -81,6 +81,10 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 	if err != nil {
 		return nil, microerror.Maskf(aws.ParsingFailedError, "unable to parse release version from AWSControlPlane")
 	}
+	namespace := awsControlPlaneCR.GetNamespace()
+	if namespace == "" {
+		namespace = "default"
+	}
 
 	var result []admission.PatchOperation
 	var numberOfAZs int
@@ -101,7 +105,7 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 				a.Log("level", "debug", "message", fmt.Sprintf("Fetching G8sControlPlane %s", awsControlPlaneCR.Name))
 				err := a.k8sClient.CtrlClient().Get(
 					ctx,
-					types.NamespacedName{Name: awsControlPlaneCR.GetName(), Namespace: awsControlPlaneCR.GetNamespace()},
+					types.NamespacedName{Name: awsControlPlaneCR.GetName(), Namespace: namespace},
 					g8sControlPlane,
 				)
 				if err != nil {
@@ -168,7 +172,7 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 				a.Log("level", "debug", "message", fmt.Sprintf("Fetching AWSCluster %s", clusterID))
 				err := a.k8sClient.CtrlClient().Get(ctx,
 					types.NamespacedName{Name: clusterID,
-						Namespace: awsControlPlaneCR.GetNamespace()},
+						Namespace: namespace},
 					AWSCluster)
 				if err != nil {
 					return microerror.Maskf(aws.NotFoundError, "failed to fetch AWSCluster: %v", err)

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane_infraref_test.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane_infraref_test.go
@@ -1,0 +1,109 @@
+package awscontrolplane
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/giantswarm/admission-controller/pkg/unittest"
+)
+
+func TestInfraRefAWSControlPlaneAdmit(t *testing.T) {
+	testCases := []struct {
+		name string
+		ctx  context.Context
+
+		expectedReferenceName string
+	}{
+		{
+			// Basic test to see whether the infrastructure reference is set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			expectedReferenceName: controlPlaneName,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+			fakeK8sClient := unittest.FakeK8sClient()
+			admit := &Admitter{
+				validAvailabilityZones: []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
+				k8sClient:              fakeK8sClient,
+				logger:                 newLogger,
+			}
+
+			// create G8sControlPlane
+			err = fakeK8sClient.CtrlClient().Create(tc.ctx, g8sControlPlaneWithoutInfraRef())
+			if err != nil {
+				t.Fatal(err)
+			}
+			// run admission request to update the infrastructure reference
+			_, err = admit.Admit(awsControlPlaneAdmissionRequest([]string{"eu-central-1a"}, "m4.xlarge", HAReleaseVersion))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// get G8sControlPlane to verify it has been updated
+			updatedG8sControlPlane := &infrastructurev1alpha2.G8sControlPlane{}
+			err = fakeK8sClient.CtrlClient().Get(
+				tc.ctx,
+				types.NamespacedName{
+					Name:      controlPlaneName,
+					Namespace: controlPlaneNameSpace,
+				},
+				updatedG8sControlPlane,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// check if the InfraRef has been set
+			if updatedG8sControlPlane.Spec.InfrastructureRef.Name != tc.expectedReferenceName {
+				t.Fatalf("expected %#q to be equal to %#q", updatedG8sControlPlane.Spec.InfrastructureRef.Name, tc.expectedReferenceName)
+			}
+
+		})
+	}
+}
+
+func g8sControlPlaneWithoutInfraRef() *infrastructurev1alpha2.G8sControlPlane {
+	g8scontrolPlane := &infrastructurev1alpha2.G8sControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "G8sControlPlane",
+			APIVersion: "infrastructure.giantswarm.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controlPlaneName,
+			Namespace: controlPlaneNameSpace,
+			Labels: map[string]string{
+				"giantswarm.io/cluster":         clusterName,
+				"giantswarm.io/control-plane":   controlPlaneName,
+				"giantswarm.io/organization":    "giantswarm",
+				"release.giantswarm.io/version": HAReleaseVersion,
+			},
+		},
+		Spec: infrastructurev1alpha2.G8sControlPlaneSpec{
+			Replicas:          1,
+			InfrastructureRef: v1.ObjectReference{},
+		},
+	}
+	return g8scontrolPlane
+}

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane_infraref_test.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane_infraref_test.go
@@ -56,7 +56,11 @@ func TestInfraRefAWSControlPlaneAdmit(t *testing.T) {
 				t.Fatal(err)
 			}
 			// run admission request to update the infrastructure reference
-			_, err = admit.Admit(awsControlPlaneAdmissionRequest([]string{"eu-central-1a"}, "m4.xlarge", HAReleaseVersion))
+			request, err := awsControlPlaneAdmissionRequest([]string{"eu-central-1a"}, "m4.xlarge", HAReleaseVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = admit.Admit(request)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane_instancetype_test.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane_instancetype_test.go
@@ -1,0 +1,79 @@
+package awscontrolplane
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/admission-controller/pkg/admission"
+	"github.com/giantswarm/admission-controller/pkg/aws"
+	"github.com/giantswarm/admission-controller/pkg/unittest"
+)
+
+func TestInstanceTypeAWSControlPlaneAdmit(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		ctx                  context.Context
+		currentInstanceType  string
+		expectedInstanceType string
+	}{
+		{
+			// Don't default the InstanceType if it is set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentInstanceType:  "m4.xlarge",
+			expectedInstanceType: "",
+		},
+		{
+			// Default the InstanceType if it is set
+			name: "case 1",
+			ctx:  context.Background(),
+
+			currentInstanceType:  "",
+			expectedInstanceType: aws.DefaultMasterInstanceType,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+			var updatedInstanceType string
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+			fakeK8sClient := unittest.FakeK8sClient()
+			admit := &Admitter{
+				validAvailabilityZones: []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
+				k8sClient:              fakeK8sClient,
+				logger:                 newLogger,
+			}
+
+			// run admission request to default AWSControlPlane InstanceType
+			var patch []admission.PatchOperation
+			patch, err = admit.Admit(awsControlPlaneAdmissionRequest([]string{"eu-central-1a", "eu-central-1b", "eu-central-1c"}, tc.currentInstanceType, HAReleaseVersion))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// parse patches
+			for _, p := range patch {
+				if p.Path == "/spec/instanceType" {
+					updatedInstanceType = p.Value.(string)
+				}
+			}
+			// check if the instanceType is as expected
+			if tc.expectedInstanceType != updatedInstanceType {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectedInstanceType, updatedInstanceType)
+			}
+		})
+	}
+}

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane_instancetype_test.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane_instancetype_test.go
@@ -60,7 +60,11 @@ func TestInstanceTypeAWSControlPlaneAdmit(t *testing.T) {
 
 			// run admission request to default AWSControlPlane InstanceType
 			var patch []admission.PatchOperation
-			patch, err = admit.Admit(awsControlPlaneAdmissionRequest([]string{"eu-central-1a", "eu-central-1b", "eu-central-1c"}, tc.currentInstanceType, HAReleaseVersion))
+			request, err := awsControlPlaneAdmissionRequest([]string{"eu-central-1a", "eu-central-1b", "eu-central-1c"}, tc.currentInstanceType, HAReleaseVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			patch, err = admit.Admit(request)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane_preHA_test.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane_preHA_test.go
@@ -92,7 +92,11 @@ func TestPreHAAWSControlPlaneAdmit(t *testing.T) {
 			}
 			// run admission request to default AWSControlPlane
 			var patch []admission.PatchOperation
-			patch, err = admit.Admit(awsControlPlaneAdmissionRequest(tc.currentAvailabilityZone, tc.currentInstanceType, preHAReleaseVersion))
+			request, err := awsControlPlaneAdmissionRequest(tc.currentAvailabilityZone, tc.currentInstanceType, preHAReleaseVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			patch, err = admit.Admit(request)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/aws/awscontrolplane/admit_awscontrolplane_preHA_test.go
+++ b/pkg/aws/awscontrolplane/admit_awscontrolplane_preHA_test.go
@@ -1,0 +1,149 @@
+package awscontrolplane
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/admission-controller/pkg/admission"
+	"github.com/giantswarm/admission-controller/pkg/unittest"
+)
+
+func TestPreHAAWSControlPlaneAdmit(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		ctx                     context.Context
+		currentAvailabilityZone []string
+		clusterAvailabilityZone string
+		expectAvailabilityZones []string
+		currentInstanceType     string
+		clusterInstanceType     string
+		expectInstanceType      string
+	}{
+		{
+			// Default AZ if it is not set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: nil,
+			clusterAvailabilityZone: "cn-south-1a",
+			expectAvailabilityZones: []string{"cn-south-1a"},
+		},
+		{
+			// Do not default AZ if it is set
+			name: "case 1",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: []string{"cn-south-1a"},
+			clusterAvailabilityZone: "cn-south-1a",
+			expectAvailabilityZones: nil,
+		},
+		{
+			// Default InstanceType if it is not set
+			name: "case 2",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: []string{"cn-south-1a"},
+			currentInstanceType:     "",
+			clusterInstanceType:     "m4.xlarge",
+			expectInstanceType:      "m4.xlarge",
+		},
+		{
+			// Do not default InstanceType if it is set
+			name: "case 3",
+			ctx:  context.Background(),
+
+			currentAvailabilityZone: []string{"cn-south-1a"},
+			currentInstanceType:     "m4.xlarge",
+			expectInstanceType:      "",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+			var updatedAZs []string
+			var updatedInstanceType string
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+			fakeK8sClient := unittest.FakeK8sClient()
+			admit := &Admitter{
+				validAvailabilityZones: []string{"cn-south-1a"},
+				k8sClient:              fakeK8sClient,
+				logger:                 newLogger,
+			}
+
+			// create AWSCluster
+			err = fakeK8sClient.CtrlClient().Create(tc.ctx, awsCluster(tc.clusterInstanceType, tc.clusterAvailabilityZone))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// run admission request to default AWSControlPlane
+			var patch []admission.PatchOperation
+			patch, err = admit.Admit(awsControlPlaneAdmissionRequest(tc.currentAvailabilityZone, tc.currentInstanceType, preHAReleaseVersion))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// parse patches
+			for _, p := range patch {
+				if p.Path == "/spec/availabilityZones" {
+					updatedAZs = p.Value.([]string)
+				} else if p.Path == "/spec/instanceType" {
+					updatedInstanceType = p.Value.(string)
+				}
+			}
+			// check if the AZ is as expected
+			if len(tc.expectAvailabilityZones) != len(updatedAZs) {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectAvailabilityZones, updatedAZs)
+			} else if len(tc.expectAvailabilityZones) > 0 {
+				if tc.expectAvailabilityZones[0] != updatedAZs[0] {
+					t.Fatalf("expected %#q to be equal to %#q", tc.expectAvailabilityZones, updatedAZs)
+				}
+			}
+			// check if the instanceType is as expected
+			if tc.expectInstanceType != updatedInstanceType {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectInstanceType, updatedInstanceType)
+			}
+		})
+	}
+}
+
+func awsCluster(instanceType string, availabilityZone string) *infrastructurev1alpha2.AWSCluster {
+	awsCluster := &infrastructurev1alpha2.AWSCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AWSCluster",
+			APIVersion: "infrastructure.giantswarm.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: controlPlaneNameSpace,
+			Labels: map[string]string{
+				"giantswarm.io/control-plane":   controlPlaneName,
+				"giantswarm.io/cluster":         clusterName,
+				"giantswarm.io/organization":    "giantswarm",
+				"release.giantswarm.io/version": preHAReleaseVersion,
+			},
+		},
+		Spec: infrastructurev1alpha2.AWSClusterSpec{
+			Provider: infrastructurev1alpha2.AWSClusterSpecProvider{
+				Master: infrastructurev1alpha2.AWSClusterSpecProviderMaster{
+					InstanceType:     instanceType,
+					AvailabilityZone: availabilityZone,
+				},
+			},
+		},
+	}
+	return awsCluster
+}

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -13,6 +13,9 @@ const (
 
 	// FirstHARelease is the first GS release for AWS that supports HA Masters
 	FirstHARelease = "11.4.0"
+
+	// CreateOperation is the string attribute in an admission request for creation
+	CreateOperation = "CREATE"
 )
 
 // IsHAVersion returns whether a given releaseVersion supports HA Masters

--- a/pkg/aws/g8scontrolplane/admit_g8scontrolplane.go
+++ b/pkg/aws/g8scontrolplane/admit_g8scontrolplane.go
@@ -89,6 +89,10 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 	if err != nil {
 		return nil, microerror.Maskf(aws.ParsingFailedError, "unable to parse release version from AWSControlPlane")
 	}
+	namespace := g8sControlPlaneNewCR.GetNamespace()
+	if namespace == "" {
+		namespace = "default"
+	}
 
 	var result []admission.PatchOperation
 	var replicas int
@@ -110,7 +114,7 @@ func (a *Admitter) Admit(request *v1beta1.AdmissionRequest) ([]admission.PatchOp
 				a.Log("level", "debug", "message", fmt.Sprintf("Fetching AWSControlPlane %s", g8sControlPlaneNewCR.Name))
 				err := a.k8sClient.CtrlClient().Get(ctx,
 					types.NamespacedName{Name: g8sControlPlaneNewCR.GetName(),
-						Namespace: g8sControlPlaneNewCR.GetNamespace()},
+						Namespace: namespace},
 					awsControlPlane)
 				if err != nil {
 					return microerror.Maskf(aws.NotFoundError, "failed to fetch AWSControlplane: %v", err)

--- a/pkg/aws/g8scontrolplane/admit_g8scontrolplane_AZ_test.go
+++ b/pkg/aws/g8scontrolplane/admit_g8scontrolplane_AZ_test.go
@@ -34,6 +34,7 @@ func TestAZG8sControlPlaneAdmit(t *testing.T) {
 		validAvailabilityZones  []string
 	}{
 		{
+			// Update from 1 to 3 Masters with 3 valid AZs
 			name: "case 0",
 			ctx:  context.Background(),
 
@@ -42,6 +43,7 @@ func TestAZG8sControlPlaneAdmit(t *testing.T) {
 			validAvailabilityZones:  []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
 		},
 		{
+			// Update from 1 to 3 Masters with 2 valid AZs
 			name: "case 1",
 			ctx:  context.Background(),
 
@@ -50,6 +52,7 @@ func TestAZG8sControlPlaneAdmit(t *testing.T) {
 			validAvailabilityZones:  []string{"cn-north-1a", "cn-north-1b"},
 		},
 		{
+			// Update from 1 to 3 Masters with 1 valid AZ
 			name: "case 2",
 			ctx:  context.Background(),
 
@@ -139,18 +142,18 @@ func g8sControlPlaneUpdateAdmissionRequest() *v1beta1.AdmissionRequest {
 		},
 		Operation: v1beta1.Update,
 		Object: runtime.RawExtension{
-			Raw:    getG8sControlPlaneRAWByte(3),
+			Raw:    getG8sControlPlaneRAWByte(3, "11.5.0"),
 			Object: nil,
 		},
 		OldObject: runtime.RawExtension{
-			Raw:    getG8sControlPlaneRAWByte(1),
+			Raw:    getG8sControlPlaneRAWByte(1, "11.5.0"),
 			Object: nil,
 		},
 	}
 	return req
 }
 
-func getG8sControlPlaneRAWByte(replicaNum int) []byte {
+func getG8sControlPlaneRAWByte(replicaNum int, release string) []byte {
 	g8scontrolPlane := infrastructurev1alpha2.G8sControlPlane{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "G8sControlPlane",
@@ -162,7 +165,7 @@ func getG8sControlPlaneRAWByte(replicaNum int) []byte {
 			Labels: map[string]string{
 				"giantswarm.io/control-plane":   controlPlaneName,
 				"giantswarm.io/organization":    "giantswarm",
-				"release.giantswarm.io/version": "11.5.0",
+				"release.giantswarm.io/version": release,
 			},
 		},
 		Spec: infrastructurev1alpha2.G8sControlPlaneSpec{

--- a/pkg/aws/g8scontrolplane/admit_g8scontrolplane_infraref_test.go
+++ b/pkg/aws/g8scontrolplane/admit_g8scontrolplane_infraref_test.go
@@ -1,0 +1,135 @@
+package g8scontrolplane
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/admission-controller/pkg/admission"
+	"github.com/giantswarm/admission-controller/pkg/unittest"
+)
+
+func TestInfraRefG8sControlPlaneAdmit(t *testing.T) {
+	testCases := []struct {
+		name string
+		ctx  context.Context
+
+		expectedReferenceName string
+		awsControlPlaneExists bool
+	}{
+		{
+			// An AWSControlPlane exists
+			name: "case 0",
+			ctx:  context.Background(),
+
+			awsControlPlaneExists: true,
+			expectedReferenceName: controlPlaneName,
+		},
+		{
+			// No AWSControlPlane exists
+			name: "case 1",
+			ctx:  context.Background(),
+
+			awsControlPlaneExists: false,
+			expectedReferenceName: "",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+			var updatedInfraRefName string
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+			fakeK8sClient := unittest.FakeK8sClient()
+			admit := &Admitter{
+				validAvailabilityZones: []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
+				k8sClient:              fakeK8sClient,
+				logger:                 newLogger,
+			}
+			// create AWSControlPlane if needed
+			if tc.awsControlPlaneExists {
+				err = fakeK8sClient.CtrlClient().Create(tc.ctx, awsControlPlane([]string{"eu-central-1a", "eu-central-1b", "eu-central-1c"}))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// run admission request for g8sControlPlane without reference
+			var patch []admission.PatchOperation
+			patch, err = admit.Admit(g8sControlPlaneNoReferenceAdmissionRequest())
+			if err != nil {
+				t.Fatal(err)
+			}
+			// parse patches
+			for _, p := range patch {
+				if p.Path == "/spec/infrastructureRef" {
+					updatedInfraRefName = p.Value.(*v1.ObjectReference).Name
+				}
+			}
+			// check if the reference patch is as expected
+			if tc.expectedReferenceName != updatedInfraRefName {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectedReferenceName, updatedInfraRefName)
+			}
+		})
+	}
+}
+
+func g8sControlPlaneNoReferenceAdmissionRequest() *v1beta1.AdmissionRequest {
+	req := &v1beta1.AdmissionRequest{
+		Kind: metav1.GroupVersionKind{
+			Version: "infrastructure.giantswarm.io/v1alpha2",
+			Kind:    "G8sControlPlane",
+		},
+		Resource: metav1.GroupVersionResource{
+			Version:  "infrastructure.giantswarm.io/v1alpha2",
+			Resource: "g8scontrolplanes",
+		},
+		Operation: v1beta1.Create,
+		Object: runtime.RawExtension{
+			Raw:    getG8sControlPlaneNoRefRAWByte(),
+			Object: nil,
+		},
+	}
+	return req
+}
+
+func getG8sControlPlaneNoRefRAWByte() []byte {
+	g8scontrolPlane := &infrastructurev1alpha2.G8sControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "G8sControlPlane",
+			APIVersion: "infrastructure.giantswarm.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controlPlaneName,
+			Namespace: controlPlaneNameSpace,
+			Labels: map[string]string{
+				"giantswarm.io/control-plane":   controlPlaneName,
+				"giantswarm.io/organization":    "giantswarm",
+				"release.giantswarm.io/version": "11.5.0",
+			},
+		},
+		Spec: infrastructurev1alpha2.G8sControlPlaneSpec{
+			Replicas:          1,
+			InfrastructureRef: v1.ObjectReference{},
+		},
+	}
+	byt, _ := json.Marshal(g8scontrolPlane)
+	return byt
+}


### PR DESCRIPTION
Right now we need to create the `g8scontrolplane` before the `awscontrolplane` if we want information about master replicas. However, we then need to update the `g8scontrolplane` again to save the infrastructure reference. This order of creation is ensured in the `api` and sometimes we see errors when there is lag. 
This PR adds the infrastructure reference update to the `admission-controller` for both CRs so that the order of creation becomes irrelevant and cluster creation more robust. It should also ease this problem: https://github.com/giantswarm/giantswarm/issues/12231